### PR TITLE
Switch double-quoted strings to single-quoted strings in SQL expressions

### DIFF
--- a/bash-history-sqlite.sh
+++ b/bash-history-sqlite.sh
@@ -19,17 +19,17 @@ source ${HOME}/.bash-preexec.sh
 # TODO figure out how to integrate this with the history builtins
 
 dbhistory() {
-    sqlite3 -separator '#' ${HISTDB} "select command_id, command from command where command like "\""%${@}%"\"";" | awk -F'#' '/^[0-9]+#/ {printf "%8s    %s\n", $1, substr($0,index($0,FS)+1); next} { print $0; }'
+    sqlite3 -separator '#' ${HISTDB} "select command_id, command from command where command like '%${@}%';" | awk -F'#' '/^[0-9]+#/ {printf "%8s    %s\n", $1, substr($0,index($0,FS)+1); next} { print $0; }'
 }
 
 dbhist() {
-    dbhistory $@
+    dbhistory "$@"
 }
 
 # TODO figure out how to make this function rewrite history so the up arrow
 #  (or ^r searches) give you what you ran, and not the dbexec() call.
 dbexec() {
-    bash -c "$(sqlite3 ${HISTDB} "select command from command where command_id="\""${1}"\"";")"
+    bash -c "$(sqlite3 "${HISTDB}" "select command from command where command_id='${1}';")"
 }
 
 
@@ -80,7 +80,7 @@ preexec_bash_history_sqlite() {
 			'bash',
 			$(__quote_str "$cmd"),
 			$(__quote_str "$PWD"),
-			"$(date +%s%3N)",
+			'$(date +%s%3N)',
 			$(__quote_str "$HISTSESSION"),
 			$quotedloginsession
 		);
@@ -97,7 +97,7 @@ precmd_bash_history_sqlite() {
 		__create_histdb
 		sqlite3 "$HISTDB" <<- EOD
 			UPDATE command SET
-				ended="$(date +%s%3N)",
+				ended='$(date +%s%3N)',
 				return=$ret_value
 			WHERE
 				command_id=$LASTHISTID ;


### PR DESCRIPTION
According to
https://www.sqlite.org/lang_expr.html#literal_values_constants_, "A string constant is formed by enclosing the string in single quotes (').". Furthermore, according to
https://www.sqlite.org/quirks.html#dblquote, as of SQLite 3.41.0 (2023-02-21), double-quoted strings are disabled in the CLI.

Fix https://github.com/thenewwazoo/bash-history-sqlite/issues/3